### PR TITLE
Fix sorting by displayName #77

### DIFF
--- a/src/main/resources/import/hmdb/_/node.xml
+++ b/src/main/resources/import/hmdb/_/node.xml
@@ -415,6 +415,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/_templates/_/node.xml
+++ b/src/main/resources/import/hmdb/_templates/_/node.xml
@@ -241,6 +241,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/_templates/folder/_/node.xml
+++ b/src/main/resources/import/hmdb/_templates/folder/_/node.xml
@@ -397,6 +397,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/_templates/movie/_/node.xml
+++ b/src/main/resources/import/hmdb/_templates/movie/_/node.xml
@@ -366,6 +366,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/articles/_/node.xml
+++ b/src/main/resources/import/hmdb/articles/_/node.xml
@@ -241,6 +241,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/_/node.xml
+++ b/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/_/node.xml
@@ -400,6 +400,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/no-time-to-deflate-balloon-seaside-shack.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/no-time-to-deflate-balloon-seaside-shack.jpg/_/node.xml
@@ -310,6 +310,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/no-time-to-deflate-night-club.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/no-time-to-deflate-night-club.jpg/_/node.xml
@@ -311,6 +311,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/no-time-to-deflate-prison-visit.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/no-time-to-deflate-prison-visit.jpg/_/node.xml
@@ -310,6 +310,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/no-time-to-deflate-villain-safloon.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/articles/no-time-to-deflate-outpops-f9-to-become-biggest-headless-hollywood-title-of-2021/no-time-to-deflate-villain-safloon.jpg/_/node.xml
@@ -269,6 +269,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/articles/the-shoehorn-redemption-celebrates-25th-anniversary/_/node.xml
+++ b/src/main/resources/import/hmdb/articles/the-shoehorn-redemption-celebrates-25th-anniversary/_/node.xml
@@ -400,6 +400,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/_/node.xml
@@ -464,6 +464,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/no-time-to-deflate/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/no-time-to-deflate/_/node.xml
@@ -260,6 +260,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/no-time-to-deflate/no-time-to-deflate-poster.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/no-time-to-deflate/no-time-to-deflate-poster.jpg/_/node.xml
@@ -305,6 +305,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/pump-fiction/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/pump-fiction/_/node.xml
@@ -266,6 +266,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/pump-fiction/jules-and-vinco-in-pump-fiction.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/pump-fiction/jules-and-vinco-in-pump-fiction.jpg/_/node.xml
@@ -324,6 +324,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/pump-fiction/pump-fiction-poster.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/pump-fiction/pump-fiction-poster.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/s7ven/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/s7ven/_/node.xml
@@ -277,6 +277,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/s7ven/s7ven.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/s7ven/s7ven.jpg/_/node.xml
@@ -312,6 +312,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-dirigible-knight/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-dirigible-knight/_/node.xml
@@ -262,6 +262,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-dirigible-knight/the-dirigible-knight-battman-poster.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-dirigible-knight/the-dirigible-knight-battman-poster.jpg/_/node.xml
@@ -268,6 +268,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-dirigible-knight/the-jokeloon-vs-battman.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-dirigible-knight/the-jokeloon-vs-battman.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-latex/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-latex/_/node.xml
@@ -279,6 +279,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-latex/classic-latex-fight-scene.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-latex/classic-latex-fight-scene.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-latex/latex-knot-vs-agent-smudge.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-latex/latex-knot-vs-agent-smudge.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-latex/the-latex-poster.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-latex/the-latex-poster.jpg/_/node.xml
@@ -268,6 +268,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-shoehorn-redemption/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-shoehorn-redemption/_/node.xml
@@ -266,6 +266,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-shoehorn-redemption/the-boys-of-the-shoehorn-redemption.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-shoehorn-redemption/the-boys-of-the-shoehorn-redemption.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/movies/the-shoehorn-redemption/the-shoehorn-redemption-poster.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/movies/the-shoehorn-redemption/the-shoehorn-redemption-poster.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/_/node.xml
@@ -236,6 +236,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/bob-gondola/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/bob-gondola/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/bob-gondola/bob-gondola.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/bob-gondola/bob-gondola.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/brad-pittless/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/brad-pittless/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/brad-pittless/brad-pittless.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/brad-pittless/brad-pittless.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/bruce-wheezis/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/bruce-wheezis/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/bruce-wheezis/bruce-wheezis.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/bruce-wheezis/bruce-wheezis.jpg/_/node.xml
@@ -312,6 +312,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/christian-balloon/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/christian-balloon/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/christian-balloon/christian-balloon.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/christian-balloon/christian-balloon.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/christopher-knotlen/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/christopher-knotlen/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/christopher-knotlen/christopher-knotlen.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/christopher-knotlen/christopher-knotlen.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/daniel-carrigear/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/daniel-carrigear/_/node.xml
@@ -259,6 +259,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/daniel-carrigear/daniel-carrigear.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/daniel-carrigear/daniel-carrigear.jpg/_/node.xml
@@ -269,6 +269,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/frank-daraballoon/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/frank-daraballoon/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/frank-daraballoon/frank-daraballoon.png/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/frank-daraballoon/frank-daraballoon.png/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/heath-levitatus/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/heath-levitatus/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/heath-levitatus/heath-levitatus.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/heath-levitatus/heath-levitatus.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/jeffrey-wroughtair/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/jeffrey-wroughtair/_/node.xml
@@ -245,6 +245,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/jeffrey-wroughtair/jeffrey-wroughtair.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/jeffrey-wroughtair/jeffrey-wroughtair.jpg/_/node.xml
@@ -269,6 +269,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/john-travolatex/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/john-travolatex/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/john-travolatex/john-travolatex.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/john-travolatex/john-travolatex.jpg/_/node.xml
@@ -268,6 +268,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/keanu-reefs/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/keanu-reefs/_/node.xml
@@ -279,6 +279,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/keanu-reefs/keanu-reefs-portrait.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/keanu-reefs/keanu-reefs-portrait.jpg/_/node.xml
@@ -268,6 +268,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/keanu-reefs/keanu-reefs.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/keanu-reefs/keanu-reefs.jpg/_/node.xml
@@ -284,6 +284,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/kerry-aire-moss/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/kerry-aire-moss/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/kerry-aire-moss/kerry-aire-moss.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/kerry-aire-moss/kerry-aire-moss.jpg/_/node.xml
@@ -312,6 +312,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/lea-seydough/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/lea-seydough/_/node.xml
@@ -292,6 +292,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/lea-seydough/lea-seydough-by-pierre-voglatex.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/lea-seydough/lea-seydough-by-pierre-voglatex.jpg/_/node.xml
@@ -271,6 +271,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/lea-seydough/lea-seydough-cannes-2013.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/lea-seydough/lea-seydough-cannes-2013.jpg/_/node.xml
@@ -271,6 +271,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/lea-seydough/lea-seydough-cannes-2016.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/lea-seydough/lea-seydough-cannes-2016.jpg/_/node.xml
@@ -304,6 +304,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/lea-seydough/lea-seydough.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/lea-seydough/lea-seydough.jpg/_/node.xml
@@ -269,6 +269,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/morgan-floatman/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/morgan-floatman/_/node.xml
@@ -245,6 +245,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/morgan-floatman/morgan-floatman.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/morgan-floatman/morgan-floatman.jpg/_/node.xml
@@ -312,6 +312,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/quentin-tieantino/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/quentin-tieantino/_/node.xml
@@ -250,6 +250,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/quentin-tieantino/quentin-tieantino-portrait.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/quentin-tieantino/quentin-tieantino-portrait.jpg/_/node.xml
@@ -312,6 +312,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/quentin-tieantino/quentin-tieantino.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/quentin-tieantino/quentin-tieantino.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/samuel-l-jackdaw/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/samuel-l-jackdaw/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/samuel-l-jackdaw/samuel-l-jackdaw.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/samuel-l-jackdaw/samuel-l-jackdaw.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/tim-ribbons/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/tim-ribbons/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/tim-ribbons/tim-ribbons.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/tim-ribbons/tim-ribbons.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/uma-tieoffman/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/uma-tieoffman/_/node.xml
@@ -249,6 +249,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/persons/uma-tieoffman/uma-tieoffman.jpg/_/node.xml
+++ b/src/main/resources/import/hmdb/persons/uma-tieoffman/uma-tieoffman.jpg/_/node.xml
@@ -299,6 +299,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/playlists/_/node.xml
+++ b/src/main/resources/import/hmdb/playlists/_/node.xml
@@ -236,6 +236,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>

--- a/src/main/resources/import/hmdb/playlists/cto-favourite-movies/_/node.xml
+++ b/src/main/resources/import/hmdb/playlists/cto-favourite-movies/_/node.xml
@@ -258,6 +258,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <enabled>true</enabled>


### PR DESCRIPTION
## Summary

Add a `pathIndexConfig` entry for `displayName` (FULLTEXT settings + `language=en`) to every bundled `node.xml` under `src/main/resources/import/hmdb/`. This mirrors what XP's `LanguageConfigProcessor` applies during `ContentService.create` on a `language=en` project, so the language-specific `_orderby_en` field is populated for imported content. After this change, sorting by `displayName` (or `_displayName`) on imported data yields the same collation as freshly-created content.

Mirrors enonic/app-superhero-blog#172 (commit `3a54a7f`).

Closes #77

## Test plan

- [ ] Build the app (`enonic project build`) on a fresh XP sandbox
- [ ] Deploy and trigger the first-boot importer (clean `cms.hmdb` repo)
- [ ] In Content Studio, open `/hmdb/movies` and `/hmdb/persons`, sort by Display Name — verify alphabetical order is correct
- [ ] Programmatic check via XP REST/Node API: `findByParent({ parentKey: '/hmdb/movies', childOrder: '_displayName ASC' })` returns children in displayName ASC order
- [ ] Repeat for DESC

🤖 Generated with [Claude Code](https://claude.com/claude-code)