### PR TITLE
Generify import app/project rewrite #79

### DIFF
--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,49 +1,52 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="xml" indent="yes"/>
+
   <xsl:param name="applicationId"/>
-  <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
-  <xsl:variable name="placeholderApp" select="'com.enonic.app.hmdb'"/>
-  <xsl:variable name="placeholderAppDashed" select="translate($placeholderApp, '.', '-')"/>
+  <xsl:param name="applicationIdPlaceholder"/>
+  <xsl:param name="projectName"/>
+  <xsl:param name="projectNamePlaceholder"/>
   <xsl:param name="keepPublishFirst" select="'true'"/>
-  
-  <xsl:template match="string[starts-with(text(),concat($placeholderApp,':'))]">
+
+  <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
+  <xsl:variable name="applicationIdPlaceholderDashed" select="translate($applicationIdPlaceholder, '.', '-')"/>
+
+  <!-- app key inside descriptor-style string values: "<app>:descriptor" -->
+  <xsl:template match="string[starts-with(text(), concat($applicationIdPlaceholder, ':'))]">
     <string>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@name"/>
-      </xsl:attribute>
-      <xsl:value-of select="concat($applicationId, substring-after(.,$placeholderApp))"/>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="concat($applicationId, substring-after(., $applicationIdPlaceholder))"/>
     </string>
   </xsl:template>
 
-  <xsl:template match="string[text() = $placeholderApp]">
+  <!-- bare app key string value -->
+  <xsl:template match="string[text() = $applicationIdPlaceholder]">
     <string>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@name"/>
-      </xsl:attribute>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
       <xsl:value-of select="$applicationId"/>
     </string>
   </xsl:template>
 
-  <xsl:template match="property-set/@name[. = $placeholderAppDashed]">
-    <xsl:attribute name="name">
-      <xsl:value-of select="$applicationIdDashed"/>
+  <!-- dashed app key in property-set names (x.<dashed-app>...) -->
+  <xsl:template match="property-set/@name[. = $applicationIdPlaceholderDashed]">
+    <xsl:attribute name="name"><xsl:value-of select="$applicationIdDashed"/></xsl:attribute>
+  </xsl:template>
+
+  <!-- project-role principals: role:cms.project.<placeholder>.<suffix> -->
+  <xsl:template match="principal/@key[starts-with(., concat('role:cms.project.', $projectNamePlaceholder, '.'))]">
+    <xsl:attribute name="key">
+      <xsl:value-of select="concat('role:cms.project.', $projectName, '.', substring-after(., concat('role:cms.project.', $projectNamePlaceholder, '.')))"/>
     </xsl:attribute>
   </xsl:template>
 
   <xsl:template match="@*|node()">
-    <xsl:copy>
-      <xsl:apply-templates select="@*|node()"/>
-    </xsl:copy>
+    <xsl:copy><xsl:apply-templates select="@*|node()"/></xsl:copy>
   </xsl:template>
 
   <!-- Remove publishing metadata on import -->
   <xsl:template match="data/property-set[@name='publish']">
     <xsl:if test="$keepPublishFirst != 'false'">
-      <xsl:copy>
-        <xsl:apply-templates select="@*|*[@name='first']"/>
-      </xsl:copy>
+      <xsl:copy><xsl:apply-templates select="@*|*[@name='first']"/></xsl:copy>
     </xsl:if>
   </xsl:template>
-
 </xsl:stylesheet>

--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -3,10 +3,12 @@
   <xsl:output method="xml" indent="yes"/>
 
   <xsl:param name="applicationId"/>
-  <xsl:param name="applicationIdPlaceholder"/>
   <xsl:param name="projectName"/>
-  <xsl:param name="projectNamePlaceholder"/>
   <xsl:param name="keepPublishFirst" select="'true'"/>
+
+  <!-- Values the bundled /import data was exported with -->
+  <xsl:variable name="applicationIdPlaceholder" select="'com.enonic.app.hmdb'"/>
+  <xsl:variable name="projectNamePlaceholder" select="'hmdb'"/>
 
   <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
   <xsl:variable name="applicationIdPlaceholderDashed" select="translate($applicationIdPlaceholder, '.', '-')"/>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -78,7 +78,10 @@ function createContent() {
         targetNodePath: '/content',
         xslt: resolve('/import/replace_app.xsl'),
         xsltParams: {
-            applicationId: app.name
+            applicationId: app.name,
+            applicationIdPlaceholder: 'com.enonic.app.hmdb',
+            projectName: projectData.id,
+            projectNamePlaceholder: 'hmdb'
         },
         versionAttributes: {
             'content.import': {

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -79,9 +79,7 @@ function createContent() {
         xslt: resolve('/import/replace_app.xsl'),
         xsltParams: {
             applicationId: app.name,
-            applicationIdPlaceholder: 'com.enonic.app.hmdb',
-            projectName: projectData.id,
-            projectNamePlaceholder: 'hmdb'
+            projectName: projectData.id
         },
         versionAttributes: {
             'content.import': {


### PR DESCRIPTION
## Summary

- `src/main/resources/import/replace_app.xsl` is now fully parameter-driven (no concrete app or project literals leak in from the caller). Takes `applicationId`, `projectName`, and `keepPublishFirst`. The placeholder values the bundled `/import/hmdb` data was exported with (`com.enonic.app.hmdb` and `hmdb`) are declared **inside** the stylesheet as `<xsl:variable>`, so callers don't need to know them. Adds a new template that rewrites `role:cms.project.<placeholder>.<suffix>` principal keys to the live project name.
- `src/main/resources/main.js` passes only the live targets (`applicationId: app.name`, `projectName: projectData.id`) — a fork that renames the project gets the correct `role:cms.project.<new-id>.*` bindings on imported content. For the canonical hmdb build the project rewrite is a no-op `hmdb` → `hmdb`.

Note: the two demo apps' `replace_app.xsl` files (hmdb and superhero-blog) differ only in those two constant variables — they are no longer byte-identical, on purpose (each stylesheet now self-describes which data it can rewrite).

No data re-export needed — the bundled `/import/hmdb` already carries the five `role:cms.project.hmdb.*` principals on every `node.xml` (added by #77 / #78).

Closes #79.

## Test plan

Verified end-to-end against `xp-distro` 8.0.0-SNAPSHOT inside the dev container:

- [x] `Started application com.enonic.app.hmdb`
- [x] `Project "hmdb" successfully created`
- [x] `Published 73 content items.`
- [x] No import errors / warnings
- [x] `lib/xp/content.getPermissions` on `/hmdb` returns all 5 `role:cms.project.hmdb.*` principals (owner / editor / author / contributor / viewer)
- [x] Same check on a descendant (`/hmdb/movies`) returns the same 5 principals — XSLT rewrite is non-destructive when placeholder == projectName

🤖 Generated with [Claude Code](https://claude.com/claude-code)
