### PR TITLE
GraalJS Compatibility #133

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ dependencies {
     include xplibs.task
     include "com.enonic.lib:lib-asset:2.0.1"
     include "com.enonic.lib:lib-thymeleaf:3.0.0"
+
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -68,6 +73,28 @@ tasks.register('npmCheck', NpmTask) {
 }
 
 check.dependsOn npmCheck
+
+tasks.named('compileTestJava') {
+    dependsOn npmBuild
+}
+
+test {
+    dependsOn npmBuild
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    dependsOn npmBuild
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs
 
 tasks.withType(Copy).configureEach {
     includeEmptyDirs = false

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -83,18 +82,9 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    dependsOn npmBuild
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs
 
 tasks.withType(Copy).configureEach {
     includeEmptyDirs = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ group = com.enonic.app
 
 # XP App values
 appName = com.enonic.app.hmdb
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT
 version=7.1.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -3,7 +3,6 @@ import * as contentLib from '/lib/xp/content';
 import * as contextLib from '/lib/xp/context';
 import * as exportLib from '/lib/xp/export';
 import * as projectLib from '/lib/xp/project';
-import * as taskLib from '/lib/xp/task';
 
 interface ProjectData {
     id: string;
@@ -104,10 +103,7 @@ function initialize(): void {
     runInContext(() => {
         const project = getProject();
         if (!project) {
-            taskLib.executeFunction({
-                description: 'Importing content',
-                func: initProject
-            });
+            initProject();
         } else {
             log.debug(`Project ${project.id} exists, skipping import`);
         }

--- a/src/test/java/com/enonic/app/hmdb/MainScriptTest.java
+++ b/src/test/java/com/enonic/app/hmdb/MainScriptTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.hmdb;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class MainScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/test/main-test.js";
+    }
+}

--- a/src/test/resources/test/main-test.js
+++ b/src/test/resources/test/main-test.js
@@ -1,0 +1,73 @@
+var t = require('/lib/xp/testing');
+
+var calls = {
+    projectGet: 0,
+    projectCreate: 0,
+    importNodes: 0,
+    publish: 0,
+    createdId: null
+};
+
+t.mock('/lib/xp/cluster.js', {
+    isLeader: function () {
+        return true;
+    }
+});
+
+t.mock('/lib/xp/context.js', {
+    run: function (params, callback) {
+        return callback();
+    },
+    get: function () {
+        return {
+            authInfo: {
+                user: {
+                    key: 'user:system:su'
+                }
+            }
+        };
+    }
+});
+
+t.mock('/lib/xp/project.js', {
+    get: function () {
+        calls.projectGet++;
+        return null;
+    },
+    create: function (params) {
+        calls.projectCreate++;
+        calls.createdId = params.id;
+        return {
+            id: params.id
+        };
+    }
+});
+
+t.mock('/lib/xp/export.js', {
+    importNodes: function () {
+        calls.importNodes++;
+        return {
+            importErrors: []
+        };
+    }
+});
+
+t.mock('/lib/xp/content.js', {
+    publish: function () {
+        calls.publish++;
+        return {
+            failedContents: [],
+            pushedContents: ['/hmdb']
+        };
+    }
+});
+
+require('/main.js');
+
+exports.testInitImportsContentWhenProjectMissing = function () {
+    t.assertEquals(1, calls.projectGet, 'getProject should be called once');
+    t.assertEquals(1, calls.projectCreate, 'createProject should be called once');
+    t.assertEquals('hmdb', calls.createdId, 'created project id');
+    t.assertEquals(1, calls.importNodes, 'content should be imported synchronously');
+    t.assertEquals(1, calls.publish, 'root content should be published synchronously');
+};


### PR DESCRIPTION
Fixes #133

## What

`task.executeFunction` fails fast on GraalJS — a function is bound to the context that created it, so it cannot be handed to another thread the way Nashorn allowed. In `main.ts` it only offloaded first-boot *initialization*, and that offload no longer serves a purpose: enonic/xp#12198 holds every top-level execution until `main.js` has finished (fixes enonic/xp#7821), so the rest of the app already sees an initialized instance.

`main.ts` now calls the function directly:

```js
if (!project) {
    initProject();
}
```

No named task, no `executeFunction`. The now-unused `/lib/xp/task` import is removed. The `description` is dropped, which only affected the task list.

## Tested on both engines

The JS tests now run once per script engine — Nashorn via `test` (the platform default) and GraalJS via `testGraalJs` — both wired into `check`, mirroring `gradle/js-tests.gradle` in the platform.

A new `ScriptRunnerSupport` test (`MainScriptTest` + `src/test/resources/test/main-test.js`) loads the **compiled** `main.js`, mocks the platform libs it requires, and asserts the project is created, content imported and the root published **synchronously during `require`** — exactly what the old `executeFunction` offload would not do (and on GraalJS it would fail fast before reaching that point).

```
test         1 test, 0 failed
testGraalJs  1 test, 0 failed
```

Verified locally against a `publishToMavenLocal` build of enonic/xp#12198 (branch `claude/graaljs-support-limitations-pzu6z8`, GraalVM Community 25).

## Note on `xpVersion`

The bump to `8.1.0-SNAPSHOT` (`enonicRepo('dev')` was already present) is required by `testGraalJs`, not by the fix — the fix alone is green on Nashorn under 8.0.2. `ScriptRunnerSupport.findTestNames()` closed the script executor before the dynamic tests ran, so on GraalJS every test failed with `IllegalStateException: The Context is already closed` regardless of app code. That is fixed in enonic/xp#12198 ("Keep the script executor alive through JS test discovery").

**CI `testGraalJs` stays red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published** — the snapshot currently on `repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`. Holding this as a draft until then.

Reference: enonic/lib-sql#154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)